### PR TITLE
Add API tests for schedule creation, retrieval, and deletion

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,7 +5,7 @@ services:
       context: .
       dockerfile: Dockerfile
     labels:
-      dev.okteto.com/private: "true"
+      dev.okteto.com/private: "false"
     ports:
       - "8080:8080"
     depends_on:

--- a/okteto.yaml
+++ b/okteto.yaml
@@ -7,3 +7,13 @@ dev:
     workdir: /usr/src/app
     sync:
       - .:/usr/src/app
+
+test:
+  api:
+    image: ${OKTETO_BUILD_WAKEUP_IMAGE:-wakeup}
+    context: .
+    commands:
+      - cd /usr/src/app
+      - npm install axios
+      - chmod +x run-test.sh
+      - ./run-test.sh

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,9 @@
         "nodemon": "^3.1.9",
         "pg": "^8.14.0",
         "uuid": "^11.1.0"
+      },
+      "devDependencies": {
+        "axios": "^1.8.3"
       }
     },
     "node_modules/@types/luxon": {
@@ -55,6 +58,25 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.3.tgz",
+      "integrity": "sha512-iP4DebzoNlP/YN2dpwCgb8zoCmhtkajzS48JvwmkSkXvPI3DHc7m+XYL5tGnSlJtR6nImXZmdCuN5aP8dh1d8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -182,6 +204,19 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -244,6 +279,16 @@
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -319,6 +364,22 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -413,6 +474,43 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
+      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/forwarded": {
@@ -531,6 +629,22 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -1018,6 +1132,13 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "nodemon server.js",
     "clean": "node clean.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node test-inline.js"
   },
   "author": "",
   "license": "Apache-2.0",
@@ -18,5 +18,8 @@
     "nodemon": "^3.1.9",
     "pg": "^8.14.0",
     "uuid": "^11.1.0"
+  },
+  "devDependencies": {
+    "axios": "^1.8.3"
   }
 }

--- a/run-test.sh
+++ b/run-test.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Generate the API URL using the Okteto environment variables
+API_URL="https://wakeup-${OKTETO_NAMESPACE}.${OKTETO_DOMAIN}"
+echo "Generated API URL: $API_URL"
+
+# Run the test with the API URL as an environment variable
+API_URL=$API_URL node test-inline.js

--- a/server.js
+++ b/server.js
@@ -208,8 +208,14 @@ if (!process.env.OKTETO_URL || !process.env.OKTETO_TOKEN) {
 // Start the server
 const PORT = process.env.PORT || 8080;
 
-initializeDatabase().then(() => {
-  app.listen(PORT, () => {
-    console.log(`server ready ⏰`);
+// Only start the server if this file is run directly (not imported for testing)
+if (require.main === module) {
+  initializeDatabase().then(() => {
+    app.listen(PORT, () => {
+      console.log(`server ready ⏰`);
+    });
   });
-});
+}
+
+// Export for testing
+module.exports = app;

--- a/test-inline.js
+++ b/test-inline.js
@@ -1,0 +1,59 @@
+const axios = require('axios');
+const { v4: uuidv4 } = require('uuid');
+
+// Use environment variable for API URL
+const API_URL = process.env.API_URL || 'http://localhost:8080';
+console.log(`Using API URL: ${API_URL}`);
+
+async function runTests() {
+  const testNamespace = 'test-namespace-' + uuidv4().substring(0, 8);
+  const testSchedule = '0 9 * * *';
+  let testScheduleId;
+  
+  try {
+    console.log('1. Creating a new schedule...');
+    const createResponse = await axios.post(`${API_URL}/api/schedules`, {
+      namespace: testNamespace,
+      schedule: testSchedule
+    });
+    
+    console.log('Create response status:', createResponse.status);
+    testScheduleId = createResponse.data.id;
+    console.log('Schedule created with ID:', testScheduleId);
+    
+    console.log('2. Getting all schedules...');
+    const getResponse = await axios.get(`${API_URL}/api/schedules`);
+    
+    const createdSchedule = getResponse.data.find(s => s.id === testScheduleId);
+    if (!createdSchedule) {
+      throw new Error('Created schedule not found in the list of schedules');
+    }
+    
+    console.log('Schedule found in the list:', createdSchedule.namespace);
+    
+    console.log('3. Deleting the schedule...');
+    const deleteResponse = await axios.delete(`${API_URL}/api/schedules/${testScheduleId}`);
+    
+    console.log('Delete response status:', deleteResponse.status);
+    
+    console.log('4. Verifying the schedule was deleted...');
+    const verifyResponse = await axios.get(`${API_URL}/api/schedules`);
+    
+    const deletedSchedule = verifyResponse.data.find(s => s.id === testScheduleId);
+    if (deletedSchedule) {
+      throw new Error('Schedule was not deleted successfully');
+    }
+    
+    console.log('All tests passed successfully!');
+    process.exit(0);
+  } catch (error) {
+    console.error('Test failed:', error.message);
+    if (error.response) {
+      console.error('Response data:', error.response.data);
+      console.error('Response status:', error.response.status);
+    }
+    process.exit(1);
+  }
+}
+
+runTests();

--- a/wait-for-it.sh
+++ b/wait-for-it.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# wait-for-it.sh: Wait for a service to be available
+# Usage: ./wait-for-it.sh host:port [-t timeout] [-- command args]
+
+WAITFORIT_cmdname=${0##*/}
+
+# Default timeout is 15 seconds
+WAITFORIT_TIMEOUT=15
+WAITFORIT_QUIET=0
+WAITFORIT_HOST=""
+WAITFORIT_PORT=""
+WAITFORIT_RESULT=0
+WAITFORIT_STRICT=0
+
+function usage {
+    cat << USAGE >&2
+Usage:
+    $WAITFORIT_cmdname host:port [-t timeout] [-- command args]
+    -t TIMEOUT                  Timeout in seconds, zero for no timeout
+    -- COMMAND ARGS             Execute command with args after the test finishes
+USAGE
+    exit 1
+}
+
+function wait_for {
+    if [[ $WAITFORIT_TIMEOUT -gt 0 ]]; then
+        echo "Waiting up to $WAITFORIT_TIMEOUT seconds for $WAITFORIT_HOST:$WAITFORIT_PORT to be available"
+    else
+        echo "Waiting for $WAITFORIT_HOST:$WAITFORIT_PORT without a timeout"
+    fi
+    
+    WAITFORIT_start_ts=$(date +%s)
+    while :
+    do
+        (echo > /dev/tcp/$WAITFORIT_HOST/$WAITFORIT_PORT) >/dev/null 2>&1
+        WAITFORIT_result=$?
+        if [[ $WAITFORIT_result -eq 0 ]]; then
+            WAITFORIT_end_ts=$(date +%s)
+            echo "$WAITFORIT_HOST:$WAITFORIT_PORT is available after $((WAITFORIT_end_ts - WAITFORIT_start_ts)) seconds"
+            break
+        fi
+        sleep 1
+        
+        WAITFORIT_CURRENT_TS=$(date +%s)
+        if [[ $WAITFORIT_TIMEOUT -gt 0 && $((WAITFORIT_CURRENT_TS - WAITFORIT_start_ts)) -ge $WAITFORIT_TIMEOUT ]]; then
+            echo "Timeout occurred after waiting $WAITFORIT_TIMEOUT seconds for $WAITFORIT_HOST:$WAITFORIT_PORT"
+            WAITFORIT_RESULT=1
+            break
+        fi
+    done
+    return $WAITFORIT_RESULT
+}
+
+# Process arguments
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+        *:* )
+        WAITFORIT_HOST=$(printf "%s\n" "$1"| cut -d : -f 1)
+        WAITFORIT_PORT=$(printf "%s\n" "$1"| cut -d : -f 2)
+        shift 1
+        ;;
+        -t)
+        WAITFORIT_TIMEOUT="$2"
+        if [[ $WAITFORIT_TIMEOUT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --)
+        shift
+        WAITFORIT_CLI=("$@")
+        break
+        ;;
+        *)
+        usage
+        ;;
+    esac
+done
+
+if [[ "$WAITFORIT_HOST" == "" || "$WAITFORIT_PORT" == "" ]]; then
+    usage
+fi
+
+wait_for
+WAITFORIT_RESULT=$?
+
+if [[ $WAITFORIT_RESULT -ne 0 && $WAITFORIT_STRICT -eq 1 ]]; then
+    exit $WAITFORIT_RESULT
+fi
+
+if [[ ${#WAITFORIT_CLI[@]} -gt 0 ]]; then
+    exec "${WAITFORIT_CLI[@]}"
+else
+    exit $WAITFORIT_RESULT
+fi


### PR DESCRIPTION
This PR adds API tests that validate the schedule functionality:

1. Creates a schedule through the API
2. Gets all schedules and verifies the created schedule is in the list
3. Deletes the schedule
4. Verifies the schedule was deleted

The test uses environment variables from Okteto to dynamically generate the API URL.

Changes:
- Added test-inline.js for API testing
- Added run-test.sh to dynamically generate the API URL
- Added wait-for-it.sh utility script
- Updated okteto.yaml to include test configuration
- Updated package.json to simplify test script
- Made the wakeup service public by changing dev.okteto.com/private to false in docker-compose.yaml
- Updated server.js to export the app for testing